### PR TITLE
Revert "chore(deps): update dependency mccabe to v0.7.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ colorama==0.4.4
 contextlib2==21.6.0
 flake8==4.0.1
 jmespath==1.0.0
-mccabe==0.7.0
+mccabe==0.6.1
 pycodestyle==2.8.0
 pyflakes==2.4.0
 python-dateutil==2.8.2


### PR DESCRIPTION
Reverts angulo-solido/terrabutler#8

```
The conflict is caused by:
    The user requested mccabe==0.7.0
    flake8 4.0.1 depends on mccabe<0.7.0 and >=0.6.0
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```