### PR TITLE
Trap ctrl+C when exec.Command

### DIFF
--- a/internal/tf/tf.go
+++ b/internal/tf/tf.go
@@ -116,6 +116,14 @@ func Runner(command []string, site string) error {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(sigChan)
 
+	go func() {
+		for sig := range sigChan {
+			if cmd.Process != nil {
+				_ = cmd.Process.Signal(sig)
+			}
+		}
+	}()
+
 	// Runs the command
 	err := cmd.Run()
 	if err != nil {
@@ -157,6 +165,14 @@ func RunnerNoVisibleOutput(command []string, site string, envVars []string) ([]b
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(sigChan)
+
+	go func() {
+		for sig := range sigChan {
+			if cmd.Process != nil {
+				_ = cmd.Process.Signal(sig)
+			}
+		}
+	}()
 
 	// Runs the command
 	output, err := cmd.Output()

--- a/internal/tf/tf.go
+++ b/internal/tf/tf.go
@@ -6,9 +6,11 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"slices"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/montblu/terrabutler/internal/logger"
 	"github.com/montblu/terrabutler/internal/settings"
@@ -108,6 +110,12 @@ func Runner(command []string, site string) error {
 	cmd.Stdout = os.Stdout
 	// Prints the errors to the console
 	cmd.Stderr = os.Stderr
+
+	// Trap ctrl+C and just wait for terraform
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
+
 	// Runs the command
 	err := cmd.Run()
 	if err != nil {
@@ -144,6 +152,12 @@ func RunnerNoVisibleOutput(command []string, site string, envVars []string) ([]b
 	cmd.Env = envVars
 	// Enabling error output
 	cmd.Stderr = os.Stderr
+
+	// Trap ctrl+C and just wait for terraform
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
+
 	// Runs the command
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/tf/tf.go
+++ b/internal/tf/tf.go
@@ -1,6 +1,7 @@
 package tf
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -130,12 +131,18 @@ func Runner(command []string, site string) error {
 	// Prints the errors to the console
 	cmd.Stderr = os.Stderr
 
+	// Starts the command first so cmd.Process is fully assigned before the
+	// signal-trap goroutine reads it, avoiding a data race with exec.Cmd.Start().
+	if err := cmd.Start(); err != nil {
+		return errors.New("There was an error during execution of terraform " + command[0] + " in the site " + site + " in the environment " + utils.GetCurrentEnv() + ", Error: " + err.Error())
+	}
+
 	// Trap ctrl+C and just wait for terraform
 	stop := trapTerminationSignals(cmd)
 	defer stop()
 
-	// Runs the command
-	err := cmd.Run()
+	// Waits for the command to finish
+	err := cmd.Wait()
 	if err != nil {
 		return errors.New("There was an error during execution of terraform " + command[0] + " in the site " + site + " in the environment " + utils.GetCurrentEnv() + ", Error: " + err.Error())
 	}
@@ -170,17 +177,27 @@ func RunnerNoVisibleOutput(command []string, site string, envVars []string) ([]b
 	cmd.Env = envVars
 	// Enabling error output
 	cmd.Stderr = os.Stderr
+	// Captures stdout manually since cmd.Output() would call Start() internally,
+	// which must happen before trapTerminationSignals is set up (see below).
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	// Starts the command first so cmd.Process is fully assigned before the
+	// signal-trap goroutine reads it, avoiding a data race with exec.Cmd.Start().
+	if err := cmd.Start(); err != nil {
+		return nil, errors.New("There was an error during execution of " + strings.Join(command, " ") + " in the site " + site + " in the environment " + utils.GetCurrentEnv() + ", Error: " + err.Error())
+	}
 
 	// Trap ctrl+C and just wait for terraform
 	stop := trapTerminationSignals(cmd)
 	defer stop()
 
-	// Runs the command
-	output, err := cmd.Output()
+	// Waits for the command to finish
+	err := cmd.Wait()
 	if err != nil {
 		return nil, errors.New("There was an error during execution of " + strings.Join(command, " ") + " in the site " + site + " in the environment " + utils.GetCurrentEnv() + ", Error: " + err.Error())
 	}
-	return output, nil
+	return stdout.Bytes(), nil
 }
 
 // New commands to be used in all sites

--- a/internal/tf/tf.go
+++ b/internal/tf/tf.go
@@ -79,6 +79,25 @@ func CommandBuilder(command string, site string, args []string, options []string
 	return base_command
 }
 
+// trapTerminationSignals prevents Go's default terminate-on-signal behavior so the
+// parent can wait for the terraform child to exit cleanly, and forwards the signal
+// to the child process. Do not read sigChan for any other purpose.
+func trapTerminationSignals(cmd *exec.Cmd) (stop func()) {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		for sig := range sigChan {
+			if cmd.Process != nil {
+				_ = cmd.Process.Signal(sig)
+			}
+		}
+	}()
+	return func() {
+		signal.Stop(sigChan)
+		close(sigChan)
+	}
+}
+
 // Main runner function, which forms a terraform command and executes it
 func CommandRunner(command string, site string, args []string, options []string, needed_options string) error {
 
@@ -112,17 +131,8 @@ func Runner(command []string, site string) error {
 	cmd.Stderr = os.Stderr
 
 	// Trap ctrl+C and just wait for terraform
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	defer signal.Stop(sigChan)
-
-	go func() {
-		for sig := range sigChan {
-			if cmd.Process != nil {
-				_ = cmd.Process.Signal(sig)
-			}
-		}
-	}()
+	stop := trapTerminationSignals(cmd)
+	defer stop()
 
 	// Runs the command
 	err := cmd.Run()
@@ -162,17 +172,8 @@ func RunnerNoVisibleOutput(command []string, site string, envVars []string) ([]b
 	cmd.Stderr = os.Stderr
 
 	// Trap ctrl+C and just wait for terraform
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	defer signal.Stop(sigChan)
-
-	go func() {
-		for sig := range sigChan {
-			if cmd.Process != nil {
-				_ = cmd.Process.Signal(sig)
-			}
-		}
-	}()
+	stop := trapTerminationSignals(cmd)
+	defer stop()
 
 	// Runs the command
 	output, err := cmd.Output()


### PR DESCRIPTION
fixes #162 

We always want to wait for the `cmd.Run()` before terminating the main go process.

---

You may test this by running a tf plan and ctrl-C right after. 

Before (keeps getting stdout text after the main process has exited, no error from terrabutler code):
```sh
[env] user@host:~/path $ terrabutler tf -site data plan 
data.xxx: Reading...
data.yyy Reading...
data.zzz: Reading...
^C
Interrupt received.
Please wait for Terraform to exit or data loss may occur.
Gracefully shutting down...

Stopping operation...

[env] user@host:~/path $ data.xxx: Read complete after 2s [id=P1S0PW6]

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: execution halted
│ 
│ 
╵
╷
│ Error: blabla
│ 
│   with provider["..."],
│   on provider.tf line 1, in provider "...":
│    1: provider "..." {
│ 
│ Please see https://registry.terraform.io/providers/blabla
│ for more information about providing credentials.
│ 
│ Error: request canceled, context canceled
│ 
╵

``` 

after (waits for subprocess, terraform can handle 2x SIGTERM now, terrabutler shows error):
```sh
[env] user@host:~/path $ terrabutler tf -site data plan 
data.xxx: Reading...
data.yyy Reading...
data.zzz: Reading...
^C
Interrupt received.
Please wait for Terraform to exit or data loss may occur.
Gracefully shutting down...

Stopping operation...
data.xxx: Read complete after 2s [id=P1S0PW6]

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: execution halted
│ 
│ 
╵
╷
│ Error: blabla
│ 
│   with provider["..."],
│   on provider.tf line 1, in provider "...":
│    1: provider "..." {
│ 
│ Please see https://registry.terraform.io/providers/blabla
│ for more information about providing credentials.
│ 
│ Error: request canceled, context canceled
│ 
╵
2026-07-09T11:48:06.233+0100    ERROR   There was an error during execution of terraform terraform in the site data in the environment env, Error: exit status 1
[env] user@host:~/path $
```