### PR TITLE
feat(tf): advertise terrabutler in Terraform User-Agent

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -25,6 +25,9 @@ func Run(appName, version, commit, date string, fs afero.Fs) error {
 	// Verify the semantic version
 	_ = utils.IsSemanticVersion(version)
 
+	// Advertise terrabutler (and its version) in Terraform's User-Agent
+	tf.SetUserAgent(version)
+
 	// Changing the default help flag
 	cli.HelpFlag = &cli.BoolFlag{
 		Name:    "help",

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -54,7 +54,7 @@ func getAvailableEnvs(fs afero.Fs) ([]string, error) {
 		return nil, err
 	}
 
-	workspaces, err := runnerNoVisibleOutput([]string{"terraform", "workspace", "list"}, "inception", os.Environ())
+	workspaces, err := runnerNoVisibleOutput([]string{"terraform", "workspace", "list"}, "inception", tf.TerraformEnv())
 	if err != nil {
 		return nil, errors.New("There was an error from terraform workspace for " + org + "-" + default_env_name + " environment. Error: " + err.Error())
 	}

--- a/internal/tf/tf.go
+++ b/internal/tf/tf.go
@@ -20,6 +20,26 @@ import (
 	"golang.org/x/term"
 )
 
+// User-Agent
+const apnUserAgent = "APN_1.1/pc_2me4418zjym9qcbpo4pbtq8rl$"
+
+// userAgent is appended to Terraform's HTTP User-Agent via TF_APPEND_USER_AGENT.
+// It is set once at startup by SetUserAgent; the default is used when the build
+// version is unknown (e.g. tests or direct package use).
+var userAgent = apnUserAgent + " terrabutler"
+
+// SetUserAgent configures the User-Agent suffix Terraform reports, based on the
+// build version. Call once at startup before any terraform command runs.
+func SetUserAgent(version string) {
+	userAgent = apnUserAgent + " terrabutler/" + version
+}
+
+// TerraformEnv returns the parent environment augmented with TF_APPEND_USER_AGENT
+// so every terraform invocation identifies itself as terrabutler.
+func TerraformEnv() []string {
+	return append(os.Environ(), "TF_APPEND_USER_AGENT="+userAgent)
+}
+
 // Used for generate-options, prints arguments
 func ArgsPrint(command string, site string) string {
 	var needed_options string
@@ -124,6 +144,8 @@ func Runner(command []string, site string) error {
 	cmd := exec.Command(command[0], command[1:]...)
 	// Changes the current directory
 	cmd.Dir = utils.Paths["root"] + "/site_" + site
+	// Advertises terrabutler in Terraform's User-Agent
+	cmd.Env = TerraformEnv()
 	// Uses the console input
 	cmd.Stdin = os.Stdin
 	// Prints the output to the console
@@ -162,7 +184,7 @@ func CommandRunnerNoVisibleOutput(command string, site string, args []string, op
 	runner_command := CommandBuilder(command, site, args, options, needed_options)
 
 	// Executes the command
-	return RunnerNoVisibleOutput(runner_command, site, os.Environ())
+	return RunnerNoVisibleOutput(runner_command, site, TerraformEnv())
 
 }
 

--- a/internal/tf/tf.go
+++ b/internal/tf/tf.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/montblu/terrabutler/internal/logger"
@@ -24,20 +25,27 @@ import (
 const apnUserAgent = "APN_1.1/pc_2me4418zjym9qcbpo4pbtq8rl$"
 
 // userAgent is appended to Terraform's HTTP User-Agent via TF_APPEND_USER_AGENT.
-// It is set once at startup by SetUserAgent; the default is used when the build
-// version is unknown (e.g. tests or direct package use).
-var userAgent = apnUserAgent + " terrabutler"
+// It is normally set once at startup by SetUserAgent, but is stored behind an
+// atomic.Pointer so concurrent reads/writes stay race-free even if that
+// startup-ordering assumption changes later (e.g. a per-command override).
+var userAgent atomic.Pointer[string]
+
+func init() {
+	def := apnUserAgent + " terrabutler"
+	userAgent.Store(&def)
+}
 
 // SetUserAgent configures the User-Agent suffix Terraform reports, based on the
 // build version. Call once at startup before any terraform command runs.
 func SetUserAgent(version string) {
-	userAgent = apnUserAgent + " terrabutler/" + version
+	v := apnUserAgent + " terrabutler/" + version
+	userAgent.Store(&v)
 }
 
 // TerraformEnv returns the parent environment augmented with TF_APPEND_USER_AGENT
 // so every terraform invocation identifies itself as terrabutler.
 func TerraformEnv() []string {
-	return append(os.Environ(), "TF_APPEND_USER_AGENT="+userAgent)
+	return append(os.Environ(), "TF_APPEND_USER_AGENT="+*userAgent.Load())
 }
 
 // Used for generate-options, prints arguments

--- a/internal/tf/tf_test.go
+++ b/internal/tf/tf_test.go
@@ -2,6 +2,7 @@ package tf
 
 import (
 	"errors"
+	"os"
 	"sync"
 	"testing"
 
@@ -72,6 +73,38 @@ func TestCommandBuilder(t *testing.T) {
 	assert.Equal(t, validOutput1, validTerraformCommand1, "Failed, the first command build is not valid.")
 	assert.Equal(t, validOutput2, validTerraformCommand2, "Failed, the second command build is not valid.")
 
+}
+
+func TestTerraformUserAgent(t *testing.T) {
+	// userAgent is package-level global state; restore it so this test does not
+	// leak into others.
+	original := userAgent
+	defer func() { userAgent = original }()
+
+	// The default (used when the build version is unknown) carries the product
+	userAgent = apnUserAgent + " terrabutler"
+	assert.Contains(t, TerraformEnv(), "TF_APPEND_USER_AGENT="+apnUserAgent+" terrabutler",
+		"TerraformEnv should append the default user agent when no version is set.")
+
+	// SetUserAgent tags the user agent with the build version.
+	SetUserAgent("1.2.3")
+	assert.Equal(t, apnUserAgent+" terrabutler/1.2.3", userAgent,
+		"SetUserAgent should build a versioned user agent with the APN attribution tag.")
+
+	env := TerraformEnv()
+	assert.Contains(t, env, "TF_APPEND_USER_AGENT="+apnUserAgent+" terrabutler/1.2.3",
+		"TerraformEnv should append the versioned TF_APPEND_USER_AGENT variable.")
+	assert.Equal(t, "APN_1.1/pc_2me4418zjym9qcbpo4pbtq8rl$", apnUserAgent,
+		"The APN attribution tag must match the partner-assigned value.")
+
+	// The parent environment must still be inherited, not replaced.
+	t.Setenv("TERRABUTLER_UA_INHERIT_CHECK", "present")
+	assert.Contains(t, TerraformEnv(), "TERRABUTLER_UA_INHERIT_CHECK=present",
+		"TerraformEnv should inherit the parent environment, not overwrite it.")
+
+	// TerraformEnv must not mutate os.Environ(); it should only add one entry.
+	assert.Equal(t, len(os.Environ())+1, len(TerraformEnv()),
+		"TerraformEnv should add exactly one variable to the inherited environment.")
 }
 
 func TestInitAllSitesSuccess(t *testing.T) {

--- a/internal/tf/tf_test.go
+++ b/internal/tf/tf_test.go
@@ -78,17 +78,18 @@ func TestCommandBuilder(t *testing.T) {
 func TestTerraformUserAgent(t *testing.T) {
 	// userAgent is package-level global state; restore it so this test does not
 	// leak into others.
-	original := userAgent
-	defer func() { userAgent = original }()
+	original := *userAgent.Load()
+	defer func() { userAgent.Store(&original) }()
 
 	// The default (used when the build version is unknown) carries the product
-	userAgent = apnUserAgent + " terrabutler"
+	def := apnUserAgent + " terrabutler"
+	userAgent.Store(&def)
 	assert.Contains(t, TerraformEnv(), "TF_APPEND_USER_AGENT="+apnUserAgent+" terrabutler",
 		"TerraformEnv should append the default user agent when no version is set.")
 
 	// SetUserAgent tags the user agent with the build version.
 	SetUserAgent("1.2.3")
-	assert.Equal(t, apnUserAgent+" terrabutler/1.2.3", userAgent,
+	assert.Equal(t, apnUserAgent+" terrabutler/1.2.3", *userAgent.Load(),
 		"SetUserAgent should build a versioned user agent with the APN attribution tag.")
 
 	env := TerraformEnv()


### PR DESCRIPTION
Set TF_APPEND_USER_AGENT on every terraform invocation so requests to providers and backends identify themselves as terrabutler/<version>.

The value is configured once at startup from the build version via tf.SetUserAgent, and injected through the new tf.TerraformEnv helper at all genuine terraform call sites (Runner, CommandRunnerNoVisibleOutput, and the workspace-list lookup). The env-select hooks, which run arbitrary user commands with a minimal environment, are intentionally left untouched.

The User-Agent also carries the AWS Partner Network attribution tag.

Closes #230 