### PR TITLE
fix(cli): pass positional args to terraform in state mv

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -905,7 +905,7 @@ func Run(appName, version, commit, date string, fs afero.Fs) error {
 									if c.StringArg("DESTINATION") == "" {
 										return errors.New("missing argument 'DESTINATION'")
 									}
-									args = append(args, c.String("SOURCE"), c.String("DESTINATION"))
+									args = append(args, c.StringArg("SOURCE"), c.StringArg("DESTINATION"))
 									if c.Bool("dry-run") {
 										options = append(options, "-dry-run")
 									}


### PR DESCRIPTION
Fixes #235.

`terrabutler tf --site <site> state mv SOURCE DESTINATION` never forwarded the positional arguments to Terraform. It printed `No such option: 'SOURCE'` / `No such option: 'DESTINATION'` and then ran `terraform state mv "" ""`, which failed.

The action read the arguments with `c.String()` (flag lookup) instead of `c.StringArg()` (argument lookup). No flags with those names exist, so `InvalidFlagAccessHandler` fired and both calls returned `""`. The validation immediately above already used `c.StringArg()` correctly, which is why the `missing argument 'SOURCE'` guard never caught it.

```diff
-					args = append(args, c.String("SOURCE"), c.String("DESTINATION"))
+					args = append(args, c.StringArg("SOURCE"), c.StringArg("DESTINATION"))
```

`state list` at `internal/cli/cli.go:871-872` shows the correct pattern. Cross-checking every `cli.StringArg{Name: ...}` in the file against `c.String("<name>")` confirms this was the only occurrence, which matches the behaviour observed: `state rm`, `state show`, `state list`, `state replace-provider`, `import`, `taint` and `untaint` all handle their positional arguments correctly — `state mv` was the only broken one.

## Testing

Reproduced against v3.2.0 and confirmed the bug is still present on `master`. I did not run the build or the test suite locally, so I'm relying on CI for that — the change is a one-line swap to a method already used throughout the same file.

There is no `internal/cli/cli_test.go`, and `tf.CommandRunner` is a package-level function rather than an injectable dependency, so covering this with a unit test would mean a refactor beyond the scope of the fix. Happy to add one if you'd prefer that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
